### PR TITLE
Adiciona tradução em inglês do README.md (#40)

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,25 @@
+# Article Translations
+
+- [Project](#project)
+- [Motivation](#motivation)
+- [Community](#community)
+- [License](#license)
+
+## Project
+
+The purpose of this repository is to provide articles about ​​software development translated into Portuguese. All the content is focused on people who are starting their adventures in this area.
+
+## Motivation
+
+Why have a repository with articles translated into Portuguese? In this area it is very common to hear that knowing English is required to start, otherwise we will not be able to consume good quality content. But when we say this we are already segregating people before they ever enter the world. Why hinder people's entry if we can help them?
+
+This repository is for this, we want to curate articles `entrylvl` with translation into Portuguese.
+
+## Community
+
+For people who already have mastery over English, we believe that this is an opportunity to further expand their knowledge, since for the translation of an article people must understand the context and meaning of each word.
+
+For those who will consume the content, as these persons begins to feel more comfortable with English and start to use the translation as a way of learning.
+
+## License
+[MIT License](https://github.com/entrylvl/traducoes-de-artigos//blob/master/LICENSE)


### PR DESCRIPTION
Não achei uma forma boa de adicionar a tradução no próprio README.md, ficou um pouco desorganizado, pois não acho que seria interessante traduzir o "menu" sendo que o conteúdo de lá seria em português. Então criei um arquivo README-en.md com infos as relevantes para estrangeiros.

Caso vocês achem melhor adicionar a tradução no README.md, me indiquem onde ficaria melhor e eu arrumo :)
